### PR TITLE
chore: Auto-merge PRs when approved and CLA-signed

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,11 @@
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+      - "#approved-reviews-by>=1"
+      # See https://doc.mergify.io/conditions.html#about-status-checks
+      - "status-success=continuous-integration/travis-ci/pr"
+      # See https://colineberhardt.github.io/cla-bot/#what-is-a-cla
+      - "status-success=verification/cla-signed"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
I've already installed [cla-bot](https://github.com/apps/cla-bot) and I'll enable [Mergify](https://mergify.io/) soon after this PR gets merged.

// Re-sending https://github.com/kubernetes-incubator/kube-aws/pull/1913 as I've accidentally pull-requested against wrong repo